### PR TITLE
SE-47: add 'show-meta' and 'version' commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Here are main commands/flags:
 | any | dump-path, d | Path to dump file | `/tmp/pmm-dumps/pmm-dump-1624342596.tar.gz` |
 | any | verbose, v | Enable verbose (debug) mode | - |
 | any | allow-insecure-certs | For self-signed certificates | - |
+| show-meta | - | Shows dump meta in human readable format | - |
+| show-meta | no-prettify | Shows raw dump meta | - |
 
 For filtering you could use the following commands (will be improved in the future):
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Here are main commands/flags:
 | any | allow-insecure-certs | For self-signed certificates | - |
 | show-meta | - | Shows dump meta in human readable format | - |
 | show-meta | no-prettify | Shows raw dump meta | - |
+| version | - | Shows binary version | - |
 
 For filtering you could use the following commands (will be improved in the future):
 

--- a/cmd/transferer/main.go
+++ b/cmd/transferer/main.go
@@ -68,6 +68,9 @@ func main() {
 		// show meta command options
 		showMetaCmd  = cli.Command("show-meta", "Shows metadata from the specified dump file")
 		prettifyMeta = showMetaCmd.Flag("prettify", "Print meta in human readable format").Default("true").Bool()
+
+		// version command options
+		versionCmd = cli.Command("version", "Shows tool version of the binary")
 	)
 
 	ctx := context.Background()
@@ -251,6 +254,8 @@ func main() {
 
 			fmt.Printf("%v\n", string(jsonMeta))
 		}
+	case versionCmd.FullCommand():
+		fmt.Printf("Build: %v\n", GitCommit)
 	default:
 		log.Fatal().Msgf("Undefined command found: %s", cmd)
 	}

--- a/cmd/transferer/util.go
+++ b/cmd/transferer/util.go
@@ -83,3 +83,29 @@ func composeMeta(pmmURL string, c *fasthttp.Client) (*dump.Meta, error) {
 
 	return meta, nil
 }
+
+func ByteCountDecimal(b int64) string {
+	const unit = 1000
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "kMGTPE"[exp])
+}
+
+func ByteCountBinary(b int64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(b)/float64(div), "KMGTPE"[exp])
+}

--- a/pkg/dump/dump.go
+++ b/pkg/dump/dump.go
@@ -16,6 +16,7 @@ const (
 type Meta struct {
 	Version          TransfererVersion `json:"version"`
 	PMMServerVersion string            `json:"pmm-server-version"`
+	MaxChunkSize     int64             `json:"max_chunk_size"`
 }
 
 type TransfererVersion struct {

--- a/pkg/transferer/meta.go
+++ b/pkg/transferer/meta.go
@@ -1,0 +1,70 @@
+package transferer
+
+import (
+	"archive/tar"
+	"encoding/json"
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+	"io"
+	"io/ioutil"
+	"pmm-transferer/pkg/dump"
+)
+
+func writeMetafile(tw *tar.Writer, meta dump.Meta) error {
+	log.Debug().Msg("Writing dump meta")
+
+	metaContent, err := json.Marshal(meta)
+	if err != nil {
+		return fmt.Errorf("failed to marshal dump meta: %s", err)
+	}
+
+	err = tw.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     dump.MetaFilename,
+		Size:     int64(len(metaContent)),
+		Mode:     0600,
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to write dump meta")
+	}
+
+	if _, err = tw.Write(metaContent); err != nil {
+		return errors.Wrap(err, "failed to write dump meta content")
+	}
+
+	return nil
+}
+
+func readMetafile(r io.Reader) (*dump.Meta, error) {
+	metaBytes, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read bytes")
+	}
+
+	meta := &dump.Meta{}
+
+	if err := json.Unmarshal(metaBytes, meta); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal")
+	}
+
+	return meta, nil
+}
+
+func readAndCompareDumpMeta(r io.Reader, runtimeMeta dump.Meta) {
+	dumpMeta, err := readMetafile(r)
+	if err != nil {
+		log.Err(err).Msgf("Failed to read meta file. No version checks could be performed")
+		return
+	}
+
+	if dumpMeta.PMMServerVersion != runtimeMeta.PMMServerVersion {
+		log.Warn().Msgf("PMM Versions mismatch\nExported:\t%v\nCurrent:\t%v",
+			dumpMeta.PMMServerVersion, runtimeMeta.PMMServerVersion)
+	}
+
+	if dumpMeta.Version.GitCommit != runtimeMeta.Version.GitCommit {
+		log.Warn().Msgf("Transferer version mismatch\nExported:\t%v\nCurrent:\t%v",
+			dumpMeta.Version.GitCommit, runtimeMeta.Version.GitCommit)
+	}
+}

--- a/pkg/transferer/transferer.go
+++ b/pkg/transferer/transferer.go
@@ -4,10 +4,8 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"pmm-transferer/pkg/dump"
@@ -330,62 +328,4 @@ func (t Transferer) sourceByType(st dump.SourceType) (dump.Source, bool) {
 		}
 	}
 	return nil, false
-}
-
-func writeMetafile(tw *tar.Writer, meta dump.Meta) error {
-	log.Debug().Msg("Writing dump meta")
-
-	metaContent, err := json.Marshal(meta)
-	if err != nil {
-		return fmt.Errorf("failed to marshal dump meta: %s", err)
-	}
-
-	err = tw.WriteHeader(&tar.Header{
-		Typeflag: tar.TypeReg,
-		Name:     dump.MetaFilename,
-		Size:     int64(len(metaContent)),
-		Mode:     0600,
-	})
-	if err != nil {
-		return errors.Wrap(err, "failed to write dump meta")
-	}
-
-	if _, err = tw.Write(metaContent); err != nil {
-		return errors.Wrap(err, "failed to write dump meta content")
-	}
-
-	return nil
-}
-
-func readMetafile(r io.Reader) (*dump.Meta, error) {
-	metaBytes, err := ioutil.ReadAll(r)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to read bytes")
-	}
-
-	meta := &dump.Meta{}
-
-	if err := json.Unmarshal(metaBytes, meta); err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal")
-	}
-
-	return meta, nil
-}
-
-func readAndCompareDumpMeta(r io.Reader, runtimeMeta dump.Meta) {
-	dumpMeta, err := readMetafile(r)
-	if err != nil {
-		log.Err(err).Msgf("Failed to read meta file. No version checks could be performed")
-		return
-	}
-
-	if dumpMeta.PMMServerVersion != runtimeMeta.PMMServerVersion {
-		log.Warn().Msgf("PMM Versions mismatch\nExported:\t%v\nCurrent:\t%v",
-			dumpMeta.PMMServerVersion, runtimeMeta.PMMServerVersion)
-	}
-
-	if dumpMeta.Version.GitCommit != runtimeMeta.Version.GitCommit {
-		log.Warn().Msgf("Transferer version mismatch\nExported:\t%v\nCurrent:\t%v",
-			dumpMeta.Version.GitCommit, runtimeMeta.Version.GitCommit)
-	}
 }


### PR DESCRIPTION
`show-meta` command consumes path to dump file and shows corresponding meta data. It includes max chunk size field to tweak nginx conf on support side.